### PR TITLE
Update pslo.js

### DIFF
--- a/pslo.js
+++ b/pslo.js
@@ -228,9 +228,15 @@ function psloca() {
         all += al; 
         alll = all;
 function bracketfun() {
-   while(n<(i/7)){
-        n++
-        gth=gth+"!"  
+   while (n<(i/7)){
+        n++;
+        if (i!=0){
+          gth=gth+"!";
+        }
+        else{
+          gth=gth+" ";
+          break;
+        }
         if (n%3==0 && n!=(Math.floor(i/7)+1)) {
           gth=gth+" ";
         } 

--- a/pslo.js
+++ b/pslo.js
@@ -230,7 +230,7 @@ function psloca() {
 function bracketfun() {
    while (n<(i/7)){
         n++;
-        if (i!=0){
+        if (i>2){
           gth=gth+"!";
         }
         else{


### PR DESCRIPTION
更改感叹号行为（少于3个字符的不会添加感叹号而是只有空格，比如Win8 Beta的“OK”变成“[wdsZv][ÖK ]”）（第1个commit弄错了）